### PR TITLE
Go 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/GitbookIO/syncgroup
+
+go 1.15

--- a/mutex/runtime.go
+++ b/mutex/runtime.go
@@ -4,7 +4,6 @@ import (
 	"unsafe"
 )
 
-//go:noescape
 //go:linkname race_Enabled internal.race.Enabled
 var race_Enabled bool
 

--- a/quickhash/strhash_test.go
+++ b/quickhash/strhash_test.go
@@ -40,8 +40,8 @@ func TestStrVSByte(t *testing.T) {
 	}
 
 	for _, k := range keys {
-		h1 := AesHash(k)
-		h2 := AesByteHash([]byte(k))
+		h1 := StrHash(k)
+		h2 := ByteHash([]byte(k))
 		if h1 != h2 {
 			t.Errorf("Expected str & byte hashes to be equal got: %d vs %d", h1, h2)
 		}
@@ -58,7 +58,7 @@ func BenchmarkStrHash(b *testing.B) {
 func BenchmarkAesHash(b *testing.B) {
 	x0 := "abcdefghijklmnopqrstuvwxyz"
 	for n := 0; n < b.N; n++ {
-		AesHash(x0)
+		StrHash(x0)
 	}
 }
 


### PR DESCRIPTION
Fixes Go 1.15 incompatibilities (caused by changes in Go's runtime hashing internals) and adds a `go.mod` file

**Warning:** `quickhash` is longer deterministic beyond the lifecycle of a single process, so don't use it for persisted hashes, use `aeshash` or something else.

Fixes #6 